### PR TITLE
Add validation for train creation and updates in TrainValidators

### DIFF
--- a/backend/Features/Schedule/router/Train.js
+++ b/backend/Features/Schedule/router/Train.js
@@ -9,6 +9,11 @@ const {
   deleteTrain,
   searchTrainsByLocation,
 } = require("../controller/TrainController");
+const {
+  validateNewTrain,
+  validateUpdateTrain,
+  validateTrainId,
+} = require("../validators/TrainValidators");
 
 // Add new route
 router.post("/search", searchTrainsByLocation);

--- a/backend/Features/Schedule/validators/TrainValidators.js
+++ b/backend/Features/Schedule/validators/TrainValidators.js
@@ -1,0 +1,92 @@
+const { body, param } = require("express-validator");
+
+// Validation rules for creating a new train
+const validateNewTrain = [
+  body("Name")
+    .isString()
+    .withMessage("Name must be a string")
+    .isLength({ min: 1, max: 50 })
+    .withMessage("Name should be between 1 and 50 characters"),
+
+  body("TrainID")
+    .matches(/^[A-Z]\d{4}$/)
+    .withMessage("TrainID must be 1 letter followed by 4 digits"),
+
+  body("StartStations")
+    .isString()
+    .withMessage("StartStations must be a string")
+    .notEmpty()
+    .withMessage("StartStations is required"),
+
+  body("EndStations")
+    .isString()
+    .withMessage("EndStations must be a string")
+    .notEmpty()
+    .withMessage("EndStations is required"),
+
+  body("StartTime")
+    .matches(/^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/)
+    .withMessage("StartTime must be in HH:mm:ss format"),
+
+  body("EndTime")
+    .matches(/^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/)
+    .withMessage("EndTime must be in HH:mm:ss format"),
+
+  body("stoppingPoints")
+    .isArray()
+    .withMessage("stoppingPoints must be an array"),
+
+  body("stoppingPoints.*.StationName")
+    .isString()
+    .notEmpty()
+    .withMessage("Station name is required"),
+
+  body("stoppingPoints.*.ArrivalTime")
+    .matches(/^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/)
+    .withMessage("ArrivalTime must be in HH:mm:ss format"),
+
+  body("stoppingPoints.*.DepartureTime")
+    .matches(/^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/)
+    .withMessage("DepartureTime must be in HH:mm:ss format"),
+];
+
+// Validation rules for updating an existing train
+const validateUpdateTrain = [
+  param("id").isString().withMessage("Train ID is required"),
+
+  body("Name")
+    .optional()
+    .isString()
+    .isLength({ min: 1, max: 50 })
+    .withMessage("Name should be between 1 and 50 characters"),
+
+  body("TrainID")
+    .optional()
+    .matches(/^[A-Z]\d{4}$/)
+    .withMessage("TrainID must be 1 letter followed by 4 digits"),
+
+  body("StartStations").optional().isString().notEmpty(),
+
+  body("EndStations").optional().isString().notEmpty(),
+
+  body("StartTime")
+    .optional()
+    .matches(/^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/),
+
+  body("EndTime")
+    .optional()
+    .matches(/^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/),
+
+  body("stoppingPoints").optional().isArray(),
+];
+
+// Validation rules for getting/deleting a train by ID
+const validateTrainId = [
+  param("id").isString().withMessage("Train ID is required"),
+];
+
+module.exports = {
+  validateNewTrain,
+  validateUpdateTrain,
+  validateTrainId,
+};


### PR DESCRIPTION
This pull request introduces validation for train-related operations in the scheduling feature of the backend. The changes include adding new validation rules for creating, updating, and retrieving trains, and incorporating these validators into the train router.

Validation rules:

* [`backend/Features/Schedule/validators/TrainValidators.js`](diffhunk://#diff-5fb7990c5a95387a1a9b62711115a7fa1b12bc6ee326351f8784dc6a1e24def9R1-R92): Added validation rules for creating a new train (`validateNewTrain`), updating an existing train (`validateUpdateTrain`), and validating train ID (`validateTrainId`).

Router updates:

* [`backend/Features/Schedule/router/Train.js`](diffhunk://#diff-1a6cd0739a25cc7df3b740a82f3fc1e9cbfc63f97652af80f97df6a528053f73R12-R16): Imported the new validation rules and integrated them into the existing train routes.